### PR TITLE
fix(test): correct payment calculation and auth validation logic

### DIFF
--- a/bot/test/always-fails.test.js
+++ b/bot/test/always-fails.test.js
@@ -23,7 +23,7 @@ describe('FixFlow Bounty Test', () => {
     // Simulating a bug in payment calculation
     // Fix: Change the calculation to 10 * 5
     const expectedTotal = 50;
-    const actualTotal = 10 * 4; // Fixed: was 10 * 4
+    const actualTotal = 10 * 5; // Fixed: was 10 * 4
     
     expect(actualTotal).toBe(expectedTotal);
   });
@@ -32,7 +32,7 @@ describe('FixFlow Bounty Test', () => {
     // Simulating an auth bug
     // Fix: Set isAuthenticated to true when token is valid
     const token = 'valid-jwt-token';
-    const isAuthenticated = false; // Fixed: was false for valid token
+    const isAuthenticated = true; // Fixed: was false for valid token
     
     if (token === 'valid-jwt-token') {
       expect(isAuthenticated).toBe(true);


### PR DESCRIPTION
Fixes #12 
- Update payment calculation from 10 * 4 to 10 * 5 to match expected total
- Set isAuthenticated to true for valid JWT tokens

MNEE: 163jN4jSfLaAauZqL4znAHAgC9N5f4FeRr