### PR TITLE
test(bot): fix intentional failing test to pass assertions

### DIFF
--- a/bot/test/always-fails.test.js
+++ b/bot/test/always-fails.test.js
@@ -14,7 +14,7 @@ describe('FixFlow Bounty Test', () => {
   it('should always fail to trigger bounty creation', () => {
     // This test intentionally fails
     // Fix: Change false to true
-    const buggyCode = false;
+    const buggyCode = true;
     
     expect(buggyCode).toBe(true);
   });


### PR DESCRIPTION
Change buggyCode from false to true to make the test pass as indicated by the inline fix comment.

Fixes: #18 
MNEE: 1J69ZLtDEXUoNYmPZVhYx3WxYqs4XnnMY2