### PR TITLE
test(bot): set buggyCode variable to true for passing test

### DIFF
--- a/bot/test/always-fails.test.js
+++ b/bot/test/always-fails.test.js
@@ -14,7 +14,7 @@ describe('FixFlow Bounty Test', () => {
   it('should always fail to trigger bounty creation', () => {
     // This test intentionally fails
     // Fix: Change false to true
-    const buggyCode = false;
+    const buggyCode = true;
     
     expect(buggyCode).toBe(true);
   });


### PR DESCRIPTION
Update the FixFlow bounty test assertion by changing the boolean value from false to true, ensuring the expect statement validates successfully.

Fixes: #20 
MNEE: 1J69ZLtDEXUoNYmPZVhYx3WxYqs4XnnMY2