### PR TITLE
test(bot): fix bounty test assertions to pass

### DIFF
--- a/bot/test/always-fails.test.js
+++ b/bot/test/always-fails.test.js
@@ -14,7 +14,7 @@ describe('FixFlow Bounty Test', () => {
   it('should always fail to trigger bounty creation', () => {
     // This test intentionally fails
     // Fix: Change false to true
-    const buggyCode = false;
+    const buggyCode = true;
     
     expect(buggyCode).toBe(true);
   });
@@ -32,7 +32,7 @@ describe('FixFlow Bounty Test', () => {
     // Simulating an auth bug
     // Fix: Set isAuthenticated to true when token is valid
     const token = 'valid-jwt-token';
-    const isAuthenticated = false; // Fixed: was false for valid token
+    const isAuthenticated = true; // Fixed: was false for valid token
     
     if (token === 'valid-jwt-token') {
       expect(isAuthenticated).toBe(true);


### PR DESCRIPTION
Set buggyCode and isAuthenticated to true so that the intentionally failing tests now pass as expected.

Fixes #49 
MNEE: 0x631d73635FC827165C0508D29C5cDd8812fF08CA