### PR TITLE
fix(test): fix intentionally failing test for bounty creation

### DIFF
--- a/bot/test/always-fails.test.js
+++ b/bot/test/always-fails.test.js
@@ -14,7 +14,7 @@ describe('FixFlow Bounty Test', () => {
   it('should always fail to trigger bounty creation', () => {
     // This test intentionally fails
     // Fix: Change false to true
-    const buggyCode = false;
+    const buggyCode = true;
     
     expect(buggyCode).toBe(true);
   });


### PR DESCRIPTION
Change buggyCode value from false to true to fix the intentionally failing test that triggers bounty creation as commented in the test file.

Fixes https://github.com/tufstraka/fixflow/issues/71
MNEE: 0x631d73635FC827165C0508D29C5cDd8812fF08CA