### PR TITLE
fix(test): fix intentionally failing test by setting buggyCode to true

### DIFF
--- a/bot/test/always-fails.test.js
+++ b/bot/test/always-fails.test.js
@@ -14,7 +14,7 @@ describe('FixFlow Bounty Test', () => {
   it('should always fail to trigger bounty creation', () => {
     // This test intentionally fails
     // Fix: Change false to true
-    const buggyCode = false;
+    const buggyCode = true;
     
     expect(buggyCode).toBe(true);
   });


### PR DESCRIPTION
The failing test has been corrected by changing the buggyCode variable from false to true to match the expectation in the test.

Fixes https://github.com/tufstraka/fixflow/issues/73 https://github.com/tufstraka/fixflow/issues/74
MNEE: 0x15f7f30f3fac79db58b3f81248ac3b8381217ed6